### PR TITLE
Prevent external users of accessing the debug page

### DIFF
--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -13,8 +13,8 @@ if (isset($_SERVER['HTTP_CLIENT_IP'])
     || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
     || !in_array(@$_SERVER['REMOTE_ADDR'], array('127.0.0.1', 'fe80::1', '::1'))
 ) {
-//    header('HTTP/1.0 403 Forbidden');
-//    exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
+    header('HTTP/1.0 403 Forbidden');
+    exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
 }
 
 $loader = require_once __DIR__.'/../app/bootstrap.php.cache';


### PR DESCRIPTION
Missing best practice.
Users should not be able to access dev tools.