### PR TITLE
Added 3rd party login flags

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -42,6 +42,7 @@ twig:
         app_router: "@router"
         tre_search_link: "%tre_search_link%"
         postalcode_search_link: "%postalcode_search_link%"
+        third_party_login: %third_party_login%
 
 # Assetic Configuration
 assetic:

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -96,3 +96,9 @@ parameters:
 
     # Warn users about untrusted Organizations?
     warn_untrusted: true
+
+    # Should login be allowed from this third-party providers?
+    third_party_login:
+        facebook: true
+        twitter: true
+        google: true

--- a/src/LoginCidadao/CoreBundle/Resources/views/Default/index.html.twig
+++ b/src/LoginCidadao/CoreBundle/Resources/views/Default/index.html.twig
@@ -31,19 +31,27 @@
             </div>
         </div>
 
-        <div class="row">
-            <div class="col-md-12 text-center">
-                <div class="box connect-box lc-box clearfix">
-                    <h3>{% trans %}Use accounts from other services{% endtrans %}</h3>
-                    <p>{% trans %}If you prefer, it's possible to use other services to login or create your account.{% endtrans %}</p>
-                    <div class="row">
-                        <div class="col-md-4 text-center"><a class="connect facebook" data-href="{{ path("lc_link_facebook") }}">Facebook</a></div>
-                        <div class="col-md-4 text-center"><a class="connect twitter" href="{{ path('hwi_oauth_service_redirect', {'service': 'twitter'}) }}">Twitter</a></div>
-                        <div class="col-md-4 text-center"><a class="connect google" href="{{ path('hwi_oauth_service_redirect', {'service': 'google'}) }}">Google</a></div>
+        {% if third_party_login is not empty %}
+            <div class="row">
+                <div class="col-md-12 text-center">
+                    <div class="box connect-box lc-box clearfix">
+                        <h3>{% trans %}Use accounts from other services{% endtrans %}</h3>
+                        <p>{% trans %}If you prefer, it's possible to use other services to login or create your account.{% endtrans %}</p>
+                        <div class="row">
+                            {% if third_party_login.facebook | default(false) %}
+                                <div class="col-md-4 text-center"><a class="connect facebook" data-href="{{ path("lc_link_facebook") }}">Facebook</a></div>
+                            {% endif %}
+                            {% if third_party_login.twitter | default(false) %}
+                                <div class="col-md-4 text-center"><a class="connect twitter" href="{{ path('hwi_oauth_service_redirect', {'service': 'twitter'}) }}">Twitter</a></div>
+                            {% endif %}
+                            {% if third_party_login.google | default(false) %}
+                                <div class="col-md-4 text-center"><a class="connect google" href="{{ path('hwi_oauth_service_redirect', {'service': 'google'}) }}">Google</a></div>
+                            {% endif %}
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
+        {% endif %}
     </div>
 
 

--- a/src/LoginCidadao/CoreBundle/Resources/views/Person/profile/edit.html.twig
+++ b/src/LoginCidadao/CoreBundle/Resources/views/Person/profile/edit.html.twig
@@ -83,88 +83,97 @@
                 </div>
             </div>
 
-            <div class="panel panel-default">
-                <div class="panel-heading">
-                    <h2 class="panel-title">{{ 'Social Networks and other connections' | trans }}</h2>
-                </div>
-                <div class="panel-body">
-                    {% if app.user.facebookId is null %}
-                        <div class="connect facebook disabled">
-                            <a class="col-xs-11 col-xs-offset-1 username" href="{{ path('lc_link_facebook') }}">{{ 'Connect with Facebook' | trans }}</a>
-                        </div>
-                    {% else %}
-                        <div class="connect facebook">
-                            {% if app.user.facebookUsername is not null %}
-                                <span class="col-xs-9 col-xs-offset-1 username">{{ app.user.facebookUsername }}</span>
-                            {% else %}
-                                <span class="col-xs-9 col-xs-offset-1 username">{{ 'facebook.nousername'|trans }}</span>
-                            {% endif %}
-                            {% if app.user.hasPassword %}
-                                <a class="col-xs-2 unlink text-right"  href="{{ path('lc_unlink_facebook') }}">
-                                    <span class="glyphicon glyphicon-remove"></span>
-                                </a>
-                            {% endif %}
-                        </div>
-                    {% endif %}
-
-                    {% if app.user.twitterId is null %}
-                        <div class="connect twitter disabled">
-                            <a href="{{ path('hwi_oauth_service_redirect', {'service': 'twitter'}) }}" class="col-xs-11 col-xs-offset-1 username">{{ 'Connect with Twitter' | trans }}</a>
-                        </div>
-                    {% else %}
-                        <div class="connect twitter">
-                            {% if app.user.twitterUsername is not null %}
-                                <span class="col-xs-9 col-xs-offset-1 username">{{ app.user.twitterUsername }}</span>
-                            {% else %}
-                                <span class="col-xs-9 col-xs-offset-1 username">{{ 'twitter.nousername'|trans }}</span>
-                            {% endif %}
-                            {% if app.user.hasPassword %}
-                                <a class="col-xs-2 unlink text-right" href="{{ path('lc_unlink_twitter') }}">
-                                    <span class="glyphicon glyphicon-remove"></span>
-                                </a>
-                            {% endif %}
-                        </div>
-                    {% endif %}
-                    {% if app.user.googleId is null %}
-                        <div class="connect google disabled">
-                            <a href="{{ path('hwi_oauth_service_redirect', {'service': 'google'}) }}" class="col-xs-11 col-xs-offset-1 username">{{ 'Connect with Google' | trans }}</a>
-                        </div>
-                    {% else %}
-                        <div class="connect google">
-                            {% if app.user.googleUsername is not null %}
-                                <span class="col-xs-9 col-xs-offset-1 username">{{ app.user.googleUsername }}</span>
-                            {% else %}
-                                <span class="col-xs-9 col-xs-offset-1 username">{{ 'google.nousername'|trans }}</span>
-                            {% endif %}
-                            {% if app.user.hasPassword %}
-                                <a class="col-xs-2 unlink text-right" href="{{ path('lc_unlink_google') }}">
-                                    <span class="glyphicon glyphicon-remove"></span>
-                                </a>
-                            {% endif %}
-                        </div>
-                    {% endif %}
-                </div>
-            </div>
-
-            <div class="row social-networks">
-                <div class="col-xs-12">
-
-                    <div class="row unlink-confirmation">
-                        <div class="alert alert-danger col-xs-10 col-xs-offset-1">
-                            <p class="title">{% trans %}Do you really want to unlink <strong class="social-network-name"></strong>?{%  endtrans %}</p>
-
-                            <div class="row">
-                                <div class="col-xs-6">
-                                    <a href="#" class="btn btn-danger btn-sm btn-block confirm">{% trans %}Yes{% endtrans %}</a>
+            {% if third_party_login is not empty %}
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <h2 class="panel-title">{{ 'Social Networks and other connections' | trans }}</h2>
+                    </div>
+                    <div class="panel-body">
+                        {% if third_party_login.facebook | default(false) %}
+                            {% if app.user.facebookId is null %}
+                                <div class="connect facebook disabled">
+                                    <a class="col-xs-11 col-xs-offset-1 username" href="{{ path('lc_link_facebook') }}">{{ 'Connect with Facebook' | trans }}</a>
                                 </div>
-                                <div class="col-xs-6 text-right">
-                                    <a role="button" class="btn btn-default btn-sm btn-block cancel">{% trans %}Cancel{%  endtrans %}</a>
+                            {% else %}
+                                <div class="connect facebook">
+                                    {% if app.user.facebookUsername is not null %}
+                                        <span class="col-xs-9 col-xs-offset-1 username">{{ app.user.facebookUsername }}</span>
+                                    {% else %}
+                                        <span class="col-xs-9 col-xs-offset-1 username">{{ 'facebook.nousername'|trans }}</span>
+                                    {% endif %}
+                                    {% if app.user.hasPassword %}
+                                        <a class="col-xs-2 unlink text-right"  href="{{ path('lc_unlink_facebook') }}">
+                                            <span class="glyphicon glyphicon-remove"></span>
+                                        </a>
+                                    {% endif %}
+                                </div>
+                            {% endif %}
+                        {% endif %}
+
+                        {% if third_party_login.twitter | default(false) %}
+                            {% if app.user.twitterId is null %}
+                                <div class="connect twitter disabled">
+                                    <a href="{{ path('hwi_oauth_service_redirect', {'service': 'twitter'}) }}" class="col-xs-11 col-xs-offset-1 username">{{ 'Connect with Twitter' | trans }}</a>
+                                </div>
+                            {% else %}
+                                <div class="connect twitter">
+                                    {% if app.user.twitterUsername is not null %}
+                                        <span class="col-xs-9 col-xs-offset-1 username">{{ app.user.twitterUsername }}</span>
+                                    {% else %}
+                                        <span class="col-xs-9 col-xs-offset-1 username">{{ 'twitter.nousername'|trans }}</span>
+                                    {% endif %}
+                                    {% if app.user.hasPassword %}
+                                        <a class="col-xs-2 unlink text-right" href="{{ path('lc_unlink_twitter') }}">
+                                            <span class="glyphicon glyphicon-remove"></span>
+                                        </a>
+                                    {% endif %}
+                                </div>
+                            {% endif %}
+                        {% endif %}
+
+                        {% if third_party_login.google | default(false) %}
+                            {% if app.user.googleId is null %}
+                                <div class="connect google disabled">
+                                    <a href="{{ path('hwi_oauth_service_redirect', {'service': 'google'}) }}" class="col-xs-11 col-xs-offset-1 username">{{ 'Connect with Google' | trans }}</a>
+                                </div>
+                            {% else %}
+                                <div class="connect google">
+                                    {% if app.user.googleUsername is not null %}
+                                        <span class="col-xs-9 col-xs-offset-1 username">{{ app.user.googleUsername }}</span>
+                                    {% else %}
+                                        <span class="col-xs-9 col-xs-offset-1 username">{{ 'google.nousername'|trans }}</span>
+                                    {% endif %}
+                                    {% if app.user.hasPassword %}
+                                        <a class="col-xs-2 unlink text-right" href="{{ path('lc_unlink_google') }}">
+                                            <span class="glyphicon glyphicon-remove"></span>
+                                        </a>
+                                    {% endif %}
+                                </div>
+                            {% endif %}
+                        {% endif %}
+                    </div>
+                </div>
+
+                <div class="row social-networks">
+                    <div class="col-xs-12">
+
+                        <div class="row unlink-confirmation">
+                            <div class="alert alert-danger col-xs-10 col-xs-offset-1">
+                                <p class="title">{% trans %}Do you really want to unlink <strong class="social-network-name"></strong>?{%  endtrans %}</p>
+
+                                <div class="row">
+                                    <div class="col-xs-6">
+                                        <a href="#" class="btn btn-danger btn-sm btn-block confirm">{% trans %}Yes{% endtrans %}</a>
+                                    </div>
+                                    <div class="col-xs-6 text-right">
+                                        <a role="button" class="btn btn-default btn-sm btn-block cancel">{% trans %}Cancel{%  endtrans %}</a>
+                                    </div>
                                 </div>
                             </div>
                         </div>
                     </div>
                 </div>
-            </div>
+            {% endif %}
 
             <div class="row">
                 {% for type, messages in app.session.flashbag.all() %}


### PR DESCRIPTION
# Feature Flags for 3rd Party login providers

Now it's possible to easily hide unwanted 3rd party login providers (Facebook, Twitter or Google) by simply setting a parameter value. By default they'll be enabled:

``` yaml
# In parameters.yml...
third_party_login:
    facebook: true
    twitter: true
    google: true
```