### PR TITLE
Introducing lc:upgrade command

### DIFF
--- a/src/LoginCidadao/CoreBundle/Command/PopulateDatabaseCommand.php
+++ b/src/LoginCidadao/CoreBundle/Command/PopulateDatabaseCommand.php
@@ -18,7 +18,7 @@ class PopulateDatabaseCommand extends ContainerAwareCommand
     protected function configure()
     {
         $this
-            ->setName('login-cidadao:database:populate')
+            ->setName('lc:database:populate')
             ->setDescription('Populates the database.')
             ->addArgument('dump_folder', InputArgument::REQUIRED, 'Where are the dumps?');
     }

--- a/src/LoginCidadao/CoreBundle/Command/UpgradeCommand.php
+++ b/src/LoginCidadao/CoreBundle/Command/UpgradeCommand.php
@@ -151,5 +151,7 @@ class UpgradeCommand extends ContainerAwareCommand
             $io->error("Couldn't update the schema. Run 'doctrine:schema:update' separately to find out why");
         }
         $io->success("Database schema updated successfully!");
+
+        $this->clearMetadata($io);
     }
 }

--- a/src/LoginCidadao/CoreBundle/Command/UpgradeCommand.php
+++ b/src/LoginCidadao/CoreBundle/Command/UpgradeCommand.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace LoginCidadao\CoreBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\ArrayInput;
+use Doctrine\ORM\EntityManager;
+
+class UpgradeCommand extends ContainerAwareCommand
+{
+
+    protected function configure()
+    {
+        $this
+            ->setName('lc:upgrade')
+            ->setDescription('Perform basic upgrade commands.')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->clearMetadata($output);
+        $this->cacheClear($output);
+        //$this->installAssets($output);
+    }
+
+    /**
+     *
+     * @return EntityManager
+     */
+    private function getManager()
+    {
+        return $this->getContainer()->get('doctrine')->getManager();
+    }
+
+    private function clearMetadata(OutputInterface $output)
+    {
+        $output->writeln("Clearing Doctrine Metadata...");
+        $command = $this->getApplication()->find('doctrine:cache:clear-metadata');
+
+        $envs = $this->getEnvsInput();
+        foreach ($envs as $env => $input) {
+            $cmdOutput  = new BufferedOutput();
+            $returnCode = $command->run($input, $cmdOutput);
+
+            if ($returnCode === 0) {
+                $out = explode("\n", trim($cmdOutput->fetch()));
+                $output->writeln("[$env]\t- ".end($out));
+            }
+        }
+    }
+
+    private function installAssets(OutputInterface $output)
+    {
+        $output->write("Installing assets...\t");
+        $input    = $this->getEnvsInput()['prod'];
+        $commands = array('assets:install', 'assetic:dump');
+        foreach ($commands as $command) {
+            $cmdOutput  = new BufferedOutput();
+            $returnCode = $this->getApplication()
+                    ->find($command)->run($input, $cmdOutput);
+
+            if ($returnCode !== 0) {
+                $output->writeln("[FAIL]");
+                $output->writeln("$command failed. Run it separately to find out why.");
+                return;
+            }
+        }
+        $output->writeln("[DONE]");
+    }
+
+    private function cacheClear(OutputInterface $output)
+    {
+        $output->write("Clearing cache...\t");
+        $input   = new ArrayInput(array('--env' => 'dev', '--no-warmup'));
+        $command = $this->getApplication()->find('cache:clear');
+
+        $cmdOutput  = new BufferedOutput();
+        $returnCode = $command->run($input, $cmdOutput);
+
+        if ($returnCode !== 0) {
+            $output->writeln("[FAIL]");
+            $output->writeln("cache:clear command failed. You may need to manually delete the cache folders.");
+            return;
+        }
+
+        $output->writeln("[DONE]");
+        return;
+
+        $envs = $this->getEnvsInput(array('--no-warmup'));
+        foreach ($envs as $env => $input) {
+            $cmdOutput = new BufferedOutput();
+            try {
+                $returnCode = $command->run($input, $cmdOutput);
+            } catch (\Exception $e) {
+                $returnCode = false;
+            }
+
+            if ($returnCode !== 0) {
+                $output->writeln("[FAIL]");
+                $output->writeln("cache:clear command failed. You may need to manually delete the cache folders.");
+                return;
+            }
+            $output->writeln("$env done");
+        }
+        $output->writeln("[DONE]");
+    }
+
+    private function getEnvsInput($custom = array())
+    {
+        return array(
+            'prod' => new ArrayInput(array_merge(array('--env' => 'prod'),
+                    $custom)),
+            'env' => new ArrayInput(array_merge(array('--env' => 'dev'), $custom))
+        );
+    }
+}

--- a/src/LoginCidadao/CoreBundle/Command/UpgradeCommand.php
+++ b/src/LoginCidadao/CoreBundle/Command/UpgradeCommand.php
@@ -84,7 +84,7 @@ class UpgradeCommand extends ContainerAwareCommand
 
     private function clearCache(SymfonyStyle $io, $env)
     {
-        $io->section("Clearing cache...");
+        $io->section("Clearing cache ($env)...");
         $io->progressStart(1);
         $input   = $this->getEnvsInput($env);
         $command = $this->getApplication()->find('cache:clear');


### PR DESCRIPTION
# Introducing lc:upgrade command

Now it's easier to upgrade your `login-cidadao` instance. You just `git pull` and run the new Symfony console command `lc:upgrade` and it'll do the tasks that are usually necessary to get you going. This way you can focus on what really matters instead of spending your precious time typing several commands and eventually forgetting one or two.