### PR TITLE
Supporting Password Encoder Migration #356

### DIFF
--- a/app/Resources/FOSUserBundle/views/ChangePassword/changePassword.html.twig
+++ b/app/Resources/FOSUserBundle/views/ChangePassword/changePassword.html.twig
@@ -1,1 +1,1 @@
-{{ include("LoginCidadaoCoreBundle:Person:security.html.twig") }}
+{{ include("LoginCidadaoCoreBundle:Person:fos.changePassword.html.twig") }}

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -103,5 +103,5 @@ parameters:
         twitter: true
         google: true
 
-    # Password Encoder (CRITICAL: Read https://github.com/PROCERGS/login-cidadao/pull/357 for important instructions)
+    # Password Encoder
     default_password_encoder: bcrypt

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -103,5 +103,5 @@ parameters:
         twitter: true
         google: true
 
-    # Password Encoder
+    # Password Encoder (CRITICAL: Read https://github.com/PROCERGS/login-cidadao/pull/357 for important instructions)
     default_password_encoder: bcrypt

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -104,4 +104,4 @@ parameters:
         google: true
 
     # Password Encoder
-    default_password_encoder: sha512
+    default_password_encoder: bcrypt

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -102,3 +102,6 @@ parameters:
         facebook: true
         twitter: true
         google: true
+
+    # Password Encoder
+    default_password_encoder: sha512

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -1,7 +1,10 @@
 security:
     encoders:
-        Symfony\Component\Security\Core\User\User: sha512
-        FOS\UserBundle\Model\UserInterface: sha512
+        sha512:
+            algorithm: sha512
+        bcrypt:
+            algorithm: bcrypt
+            cost: 15
 
     role_hierarchy:
         ROLE_USER:

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -6,6 +6,10 @@ security:
             algorithm: bcrypt
             cost: 15
 
+        # The following two lines ensure BC for PR #357
+        Symfony\Component\Security\Core\User\User: sha512
+        FOS\UserBundle\Model\UserInterface: sha512
+
     role_hierarchy:
         ROLE_USER:
             - FEATURE_PROD

--- a/src/LoginCidadao/CoreBundle/Entity/Person.php
+++ b/src/LoginCidadao/CoreBundle/Entity/Person.php
@@ -2,25 +2,25 @@
 
 namespace LoginCidadao\CoreBundle\Entity;
 
-use FOS\UserBundle\Model\User as BaseUser;
-use Doctrine\ORM\Mapping as ORM;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Mapping as ORM;
 use Doctrine\Common\Collections\ArrayCollection;
-use Symfony\Component\Validator\Constraints as Assert;
-use LoginCidadao\OAuthBundle\Entity\Client;
-use JMS\Serializer\Annotation as JMS;
-use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
-use LoginCidadao\ValidationBundle\Validator\Constraints as LCAssert;
-use Vich\UploaderBundle\Mapping\Annotation as Vich;
-use Symfony\Component\HttpFoundation\File\File;
-use LoginCidadao\CoreBundle\Model\PersonInterface;
-use LoginCidadao\OAuthBundle\Model\ClientInterface;
 use Doctrine\Common\Collections\Collection;
+use Symfony\Component\HttpFoundation\File\File;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Scheb\TwoFactorBundle\Model\Google\TwoFactorInterface;
 use Scheb\TwoFactorBundle\Model\BackupCodeInterface;
-use LoginCidadao\CoreBundle\Model\LocationAwareInterface;
+use Vich\UploaderBundle\Mapping\Annotation as Vich;
+use JMS\Serializer\Annotation as JMS;
+use FOS\UserBundle\Model\User as BaseUser;
+use LoginCidadao\OAuthBundle\Entity\Client;
 use LoginCidadao\CoreBundle\Model\SelectData;
 use LoginCidadao\LongPolling\LongPollingUtils;
+use LoginCidadao\CoreBundle\Model\PersonInterface;
+use LoginCidadao\OAuthBundle\Model\ClientInterface;
+use LoginCidadao\CoreBundle\Model\LocationAwareInterface;
+use LoginCidadao\ValidationBundle\Validator\Constraints as LCAssert;
 
 /**
  * @ORM\Entity(repositoryClass="LoginCidadao\CoreBundle\Entity\PersonRepository")
@@ -377,6 +377,12 @@ class Person extends BaseUser implements PersonInterface, TwoFactorInterface, Ba
      * @ORM\OneToMany(targetEntity="BackupCode", mappedBy="person", cascade={"remove"}, orphanRemoval=true)
      */
     protected $backupCodes;
+
+    /**
+     * @JMS\Exclude
+     * @ORM\Column(name="password_encoder_name", type="string", length=255, nullable=false)
+     */
+    protected $passwordEncoderName;
 
     public function __construct()
     {
@@ -1287,5 +1293,21 @@ class Person extends BaseUser implements PersonInterface, TwoFactorInterface, Ba
     public function getPhoneNumberVerified()
     {
         return false;
+    }
+
+    public function getPasswordEncoderName()
+    {
+        return $this->passwordEncoderName;
+    }
+
+    public function setPasswordEncoderName($passwordEncoderName)
+    {
+        $this->passwordEncoderName = $passwordEncoderName;
+        return $this;
+    }
+
+    public function getEncoderName()
+    {
+        return $this->passwordEncoderName;
     }
 }

--- a/src/LoginCidadao/CoreBundle/Entity/Person.php
+++ b/src/LoginCidadao/CoreBundle/Entity/Person.php
@@ -380,7 +380,7 @@ class Person extends BaseUser implements PersonInterface, TwoFactorInterface, Ba
 
     /**
      * @JMS\Exclude
-     * @ORM\Column(name="password_encoder_name", type="string", length=255, nullable=false)
+     * @ORM\Column(name="password_encoder_name", type="string", length=255, nullable=true)
      */
     protected $passwordEncoderName;
 
@@ -1308,6 +1308,13 @@ class Person extends BaseUser implements PersonInterface, TwoFactorInterface, Ba
 
     public function getEncoderName()
     {
-        return $this->passwordEncoderName;
+        $encoder = $this->passwordEncoderName;
+
+        // BC for PR #357
+        if ($encoder === null || strlen($encoder) < 1) {
+            return null;
+        }
+
+        return $encoder;
     }
 }

--- a/src/LoginCidadao/CoreBundle/EventListener/ChangePasswordListener.php
+++ b/src/LoginCidadao/CoreBundle/EventListener/ChangePasswordListener.php
@@ -43,6 +43,7 @@ class ChangePasswordListener implements EventSubscriberInterface
     {
         return array(
             FOSUserEvents::CHANGE_PASSWORD_SUCCESS => 'onChangePasswordSuccess',
+            FOSUserEvents::RESETTING_RESET_SUCCESS => 'onChangePasswordSuccess',
             FOSUserEvents::CHANGE_PASSWORD_COMPLETED => 'onChangePasswordCompleted',
         );
     }

--- a/src/LoginCidadao/CoreBundle/EventListener/ChangePasswordListener.php
+++ b/src/LoginCidadao/CoreBundle/EventListener/ChangePasswordListener.php
@@ -43,7 +43,8 @@ class ChangePasswordListener implements EventSubscriberInterface
     {
         return array(
             FOSUserEvents::CHANGE_PASSWORD_SUCCESS => 'onChangePasswordSuccess',
-            FOSUserEvents::RESETTING_RESET_SUCCESS => 'onChangePasswordSuccess',
+            FOSUserEvents::RESETTING_RESET_SUCCESS => 'setPasswordEncoderName',
+            FOSUserEvents::REGISTRATION_SUCCESS => 'setPasswordEncoderName',
             FOSUserEvents::CHANGE_PASSWORD_COMPLETED => 'onChangePasswordCompleted',
         );
     }
@@ -51,12 +52,17 @@ class ChangePasswordListener implements EventSubscriberInterface
     public function onChangePasswordSuccess(FormEvent $event)
     {
         $person = $event->getForm()->getData();
-        $person->setPasswordEncoderName($this->defaultPasswordEncoder);
         $this->notificationHelper->clearEmptyPasswordNotification($person);
-        $this->session->remove('force_password_change');
 
         $url = $this->router->generate('fos_user_change_password');
         $event->setResponse(new RedirectResponse($url));
+    }
+
+    public function setPasswordEncoderName(FormEvent $event)
+    {
+        $person = $event->getForm()->getData();
+        $person->setPasswordEncoderName($this->defaultPasswordEncoder);
+        $this->session->remove('force_password_change');
     }
 
     public function onChangePasswordCompleted(FilterUserResponseEvent $event)

--- a/src/LoginCidadao/CoreBundle/EventListener/ChangePasswordListener.php
+++ b/src/LoginCidadao/CoreBundle/EventListener/ChangePasswordListener.php
@@ -12,15 +12,22 @@ use FOS\UserBundle\Event\FilterUserResponseEvent;
 
 class ChangePasswordListener implements EventSubscriberInterface
 {
-
+    /** @var UrlGeneratorInterface */
     private $router;
+
+    /** @var NotificationsHelper */
     private $notificationHelper;
 
+    /** @var string */
+    private $defaultPasswordEncoder;
+
     public function __construct(UrlGeneratorInterface $router,
-                                NotificationsHelper $notificationHelper)
+                                NotificationsHelper $notificationHelper,
+                                $defaultPasswordEncoder)
     {
-        $this->router = $router;
-        $this->notificationHelper = $notificationHelper;
+        $this->router                 = $router;
+        $this->notificationHelper     = $notificationHelper;
+        $this->defaultPasswordEncoder = $defaultPasswordEncoder;
     }
 
     /**
@@ -37,6 +44,7 @@ class ChangePasswordListener implements EventSubscriberInterface
     public function onChangePasswordSuccess(FormEvent $event)
     {
         $person = $event->getForm()->getData();
+        $person->setPasswordEncoderName($this->defaultPasswordEncoder);
         $this->notificationHelper->clearEmptyPasswordNotification($person);
 
         $url = $this->router->generate('fos_user_change_password');
@@ -48,5 +56,4 @@ class ChangePasswordListener implements EventSubscriberInterface
         $user = $event->getUser();
         $this->notificationHelper->clearEmptyPasswordNotification($user);
     }
-
 }

--- a/src/LoginCidadao/CoreBundle/EventListener/ChangePasswordListener.php
+++ b/src/LoginCidadao/CoreBundle/EventListener/ChangePasswordListener.php
@@ -6,6 +6,7 @@ use FOS\UserBundle\FOSUserEvents;
 use FOS\UserBundle\Event\FormEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use LoginCidadao\NotificationBundle\Helper\NotificationsHelper;
 use FOS\UserBundle\Event\FilterUserResponseEvent;
@@ -18,15 +19,20 @@ class ChangePasswordListener implements EventSubscriberInterface
     /** @var NotificationsHelper */
     private $notificationHelper;
 
+    /** @var SessionInterface */
+    private $session;
+
     /** @var string */
     private $defaultPasswordEncoder;
 
     public function __construct(UrlGeneratorInterface $router,
                                 NotificationsHelper $notificationHelper,
+                                SessionInterface $session,
                                 $defaultPasswordEncoder)
     {
         $this->router                 = $router;
         $this->notificationHelper     = $notificationHelper;
+        $this->session                = $session;
         $this->defaultPasswordEncoder = $defaultPasswordEncoder;
     }
 
@@ -46,6 +52,7 @@ class ChangePasswordListener implements EventSubscriberInterface
         $person = $event->getForm()->getData();
         $person->setPasswordEncoderName($this->defaultPasswordEncoder);
         $this->notificationHelper->clearEmptyPasswordNotification($person);
+        $this->session->remove('force_password_change');
 
         $url = $this->router->generate('fos_user_change_password');
         $event->setResponse(new RedirectResponse($url));

--- a/src/LoginCidadao/CoreBundle/EventListener/LoggedInUserListener.php
+++ b/src/LoginCidadao/CoreBundle/EventListener/LoggedInUserListener.php
@@ -2,17 +2,15 @@
 
 namespace LoginCidadao\CoreBundle\EventListener;
 
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernel;
-use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Routing\RouterInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Translation\TranslatorInterface;
-use FOS\OAuthServerBundle\Security\Authentication\Token\OAuthToken;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\Security\Core\SecurityContextInterface;
 use LoginCidadao\CoreBundle\Exception\RedirectResponseException;
 use LoginCidadao\CoreBundle\Model\PersonInterface;
-use LoginCidadao\OAuthBundle\Model\ClientUser;
 use Doctrine\ORM\EntityManager;
 
 class LoggedInUserListener
@@ -118,6 +116,7 @@ class LoggedInUserListener
         if ($person->getEncoderName() === $this->defaultPasswordEncoder) {
             return;
         }
+        $this->session->set('force_password_change', true);
 
         if ($route === 'fos_user_change_password') {
             return;

--- a/src/LoginCidadao/CoreBundle/EventListener/LoggedInUserListener.php
+++ b/src/LoginCidadao/CoreBundle/EventListener/LoggedInUserListener.php
@@ -10,6 +10,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Translation\TranslatorInterface;
 use FOS\OAuthServerBundle\Security\Authentication\Token\OAuthToken;
+use LoginCidadao\CoreBundle\Exception\RedirectResponseException;
 use LoginCidadao\CoreBundle\Model\PersonInterface;
 use LoginCidadao\OAuthBundle\Model\ClientUser;
 use Doctrine\ORM\EntityManager;
@@ -31,16 +32,21 @@ class LoggedInUserListener
     /** @var EntityManager */
     private $em;
 
+    /** @var string */
+    private $defaultPasswordEncoder;
+
     public function __construct(SecurityContextInterface $context,
                                 RouterInterface $router, Session $session,
                                 TranslatorInterface $translator,
-                                EntityManager $em)
+                                EntityManager $em, $defaultPasswordEncoder)
     {
         $this->context    = $context;
         $this->router     = $router;
         $this->session    = $session;
         $this->translator = $translator;
         $this->em         = $em;
+
+        $this->defaultPasswordEncoder = $defaultPasswordEncoder;
     }
 
     public function onKernelRequest(GetResponseEvent $event)
@@ -50,34 +56,43 @@ class LoggedInUserListener
             return;
         }
         $token = $this->context->getToken();
-        if (is_null($token)) {
+
+        if (is_null($token) ||
+            $this->context->isGranted('IS_AUTHENTICATED_REMEMBERED') === false) {
+            return;
+        }
+        if (!($token->getUser() instanceof PersonInterface)) {
+            // We don't have a PersonInterface... Nothing to do here.
             return;
         }
 
-        $_route = $event->getRequest()->attributes->get('_route');
-        if ($this->context->isGranted('IS_AUTHENTICATED_REMEMBERED')) {
-            if (!($token->getUser() instanceof PersonInterface)) {
-                // We don't have a PersonInterface... Nothing to do here.
-                return;
-            }
-
-            if ($_route == 'lc_home' || $_route == 'fos_user_security_login') {
-                $key = '_security.main.target_path'; #where "main" is your firewall name
-                //check if the referer session key has been set
-                if ($this->session->has($key)) {
-                    //set the url based on the link they were trying to access before being authenticated
-                    $url = $this->session->get($key);
-
-                    //remove the session key
-                    $this->session->remove($key);
-                } else {
-                    $url = $this->router->generate('lc_dashboard');
-                }
-                $event->setResponse(new RedirectResponse($url));
-            } else {
-                $this->checkUnconfirmedEmail();
-            }
+        try {
+            $this->handleTargetPath($event);
+            $this->passwordEncoderMigration($event);
+            $this->checkUnconfirmedEmail();
+        } catch (RedirectResponseException $e) {
+            $event->setResponse($e->getResponse());
         }
+    }
+
+    private function handleTargetPath(GetResponseEvent $event)
+    {
+        $route = $event->getRequest()->get('_route');
+        if ($route !== 'lc_home' && $route !== 'fos_user_security_login') {
+            return;
+        }
+        $key = '_security.main.target_path'; #where "main" is your firewall name
+        //check if the referer session key has been set
+        if ($this->session->has($key)) {
+            //set the url based on the link they were trying to access before being authenticated
+            $url = $this->session->get($key);
+
+            //remove the session key
+            $this->session->remove($key);
+        } else {
+            $url = $this->router->generate('lc_dashboard');
+        }
+        throw new RedirectResponseException(new RedirectResponse($url));
     }
 
     protected function checkUnconfirmedEmail()
@@ -93,5 +108,22 @@ class LoggedInUserListener
 
             $this->session->getFlashBag()->add('alert.unconfirmed.email', $alert);
         }
+    }
+
+    private function passwordEncoderMigration(GetResponseEvent $event)
+    {
+        $person = $this->context->getToken()->getUser();
+        $route  = $event->getRequest()->get('_route');
+
+        if ($person->getEncoderName() === $this->defaultPasswordEncoder) {
+            return;
+        }
+
+        if ($route === 'fos_user_change_password') {
+            return;
+        }
+
+        $url = $this->router->generate('fos_user_change_password');
+        throw new RedirectResponseException(new RedirectResponse($url));
     }
 }

--- a/src/LoginCidadao/CoreBundle/Exception/RedirectResponseException.php
+++ b/src/LoginCidadao/CoreBundle/Exception/RedirectResponseException.php
@@ -1,0 +1,28 @@
+<?php
+/*
+ * This file is part of the login-cidadao project or it's bundles.
+ *
+ * (c) Guilherme Donato <guilhermednt on github>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace LoginCidadao\CoreBundle\Exception;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+class RedirectResponseException extends \Exception
+{
+    private $response;
+
+    public function __construct(RedirectResponse $response)
+    {
+        $this->response = $response;
+    }
+
+    public function getResponse()
+    {
+        return $this->response;
+    }
+}

--- a/src/LoginCidadao/CoreBundle/Model/PersonInterface.php
+++ b/src/LoginCidadao/CoreBundle/Model/PersonInterface.php
@@ -2,11 +2,12 @@
 
 namespace LoginCidadao\CoreBundle\Model;
 
+use Symfony\Component\Security\Core\Encoder\EncoderAwareInterface;
 use LoginCidadao\OAuthBundle\Entity\Client;
 use JMS\Serializer\Annotation as JMS;
 use Doctrine\ORM\EntityManager;
 
-interface PersonInterface
+interface PersonInterface extends EncoderAwareInterface
 {
 
     public function getEmail();
@@ -199,6 +200,7 @@ interface PersonInterface
     public function getGoogleAuthenticatorSecret();
 
     public function setGoogleAuthenticatorSecret($googleAuthenticatorSecret);
+
     /**
      * @param EntityManager $em
      * @param \DateTime $updatedAt

--- a/src/LoginCidadao/CoreBundle/Resources/config/services.yml
+++ b/src/LoginCidadao/CoreBundle/Resources/config/services.yml
@@ -155,6 +155,7 @@ services:
         arguments:
             - @router
             - @notifications.helper
+            - @session
             - %default_password_encoder%
         tags:
             - { name: kernel.event_subscriber }

--- a/src/LoginCidadao/CoreBundle/Resources/config/services.yml
+++ b/src/LoginCidadao/CoreBundle/Resources/config/services.yml
@@ -152,7 +152,10 @@ services:
 
     lc.change_password_listener:
         class: %lc.change.password.listener.class%
-        arguments: ["@router", "@notifications.helper"]
+        arguments:
+            - @router
+            - @notifications.helper
+            - %default_password_encoder%
         tags:
             - { name: kernel.event_subscriber }
 
@@ -168,7 +171,13 @@ services:
 
     kernel.listener.logged_in_user_listener:
         class: %kernel.listener.logged_in_user_listener.class%
-        arguments: [ "@security.context", "@router", "@session", "@translator", "@doctrine.orm.entity_manager" ]
+        arguments:
+            - @security.context
+            - @router
+            - @session
+            - @translator
+            - @doctrine.orm.entity_manager
+            - %default_password_encoder%
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
 

--- a/src/LoginCidadao/CoreBundle/Resources/translations/FOSUserBundle.pt_BR.yml
+++ b/src/LoginCidadao/CoreBundle/Resources/translations/FOSUserBundle.pt_BR.yml
@@ -46,7 +46,7 @@ resetting.email.message: 'Alguém solicitou recentemente para redefinir sua senh
 resetting.reset.submit: 'Alterar senha'
 resetting.password_already_requested: 'Este usuário já solicitou uma senha nas últimas 24 horas.'
 change_password.submit: 'Alterar senha'
-change_password.flash.success: 'Senha alterada com sucesso!.'
+change_password.flash.success: 'Senha alterada com sucesso!'
 'As a safety measure we need you to type your password to confirm any changes.': 'Como medida de segurança, por favor informe sua senha para confirmar quaisquer mudanças.'
 'Reset Password': 'Redefinir senha'
 Cancel: Cancelar

--- a/src/LoginCidadao/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/LoginCidadao/CoreBundle/Resources/translations/messages.en.yml
@@ -392,3 +392,5 @@ admin:
     person:
         list: 'Manage People'
         list.title:  'Search People'
+force_password_change:
+    description: Please update your password to improve your account's security.

--- a/src/LoginCidadao/CoreBundle/Resources/translations/messages.pt_BR.yml
+++ b/src/LoginCidadao/CoreBundle/Resources/translations/messages.pt_BR.yml
@@ -812,3 +812,5 @@ admin:
     person:
         list: 'Gerenciar pessoas'
         list.title:  'Busca de pessoas'
+force_password_change:
+    description: Por favor, atualize sua senha para melhorar a segurança de sua conta.

--- a/src/LoginCidadao/CoreBundle/Resources/views/Person/forceChangePassword.html.twig
+++ b/src/LoginCidadao/CoreBundle/Resources/views/Person/forceChangePassword.html.twig
@@ -1,0 +1,23 @@
+{% extends "LoginCidadaoCoreBundle::base.loggedIn.html.twig" %}
+
+{% block title %}{{ 'Security' | trans }} | {{ parent() }}{% endblock title %}
+
+{% block content %}
+    <div class="form-content">
+        <div class="content security clearfix">
+            <h1 class="visible-xs">{{ 'Security' | trans }}</h1>
+            <p>{{ 'force_password_change.description' | trans }}</p>
+            {{ include("LoginCidadaoCoreBundle:Person:changePassword.html.twig") }}
+        </div>
+    </div>
+{% endblock %}
+
+{% block content_columns %}container{% endblock %}
+{% block sidebar %}{% endblock %}
+{% block notificationExtreme %}
+    {{ include("LoginCidadaoCoreBundle::notification_extreme.html.twig", { columns: block('content_columns') } ) }}
+{% endblock %}
+{% block footer %}
+    {% set columns = block('content_columns') %}
+    {{ include("LoginCidadaoCoreBundle::footer.html.twig") }}
+{% endblock %}

--- a/src/LoginCidadao/CoreBundle/Resources/views/Person/fos.changePassword.html.twig
+++ b/src/LoginCidadao/CoreBundle/Resources/views/Person/fos.changePassword.html.twig
@@ -1,0 +1,5 @@
+{% if app.session.get('force_password_change') == true %}
+    {{ include("LoginCidadaoCoreBundle:Person:forceChangePassword.html.twig") }}
+{% else %}
+    {{ include("LoginCidadaoCoreBundle:Person:security.html.twig") }}
+{% endif %}

--- a/src/LoginCidadao/CoreBundle/Resources/views/Person/security.html.twig
+++ b/src/LoginCidadao/CoreBundle/Resources/views/Person/security.html.twig
@@ -1,6 +1,5 @@
 {% extends "LoginCidadaoCoreBundle::base.loggedIn.html.twig" %}
 
-
 {% block title %}{{ 'Security' | trans }} | {{ parent() }}{% endblock title %}
 
 {% block content %}


### PR DESCRIPTION
# Password Encoder Migration #356 

Symfony has a nice feature that allows to configure different password encoders to each user. Thanks to that, it was possible to implement a migration strategy so that when better encoders become available it's possible to migrate gradually to them.