### PR TITLE
v1.21.0

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,0 +1,5 @@
+# Trusted proxies (https://symfony.com/doc/3.4/deployment/proxies.html#solution-settrustedproxies)
+TRUSTED_PROXIES=127.0.0.1,172.17.0.0/16,172.29.0.0/16,172.28.6.27,200.198.128.180,200.198.128.224
+
+# IPs allowed to access dev environment
+DEV_ALLOWED=127.0.0.0/8,172.17.0.0/16,172.29.0.0/16,172.28.0.0/16,10.124.0.0/16,10.127.9.0/24

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 /.vagrant
 .idea
 /doc/site
+.env

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -27,7 +27,6 @@ framework:
         engines: ['twig']
         #assets_version: SomeVersionScheme
     default_locale:  "%locale%"
-    trusted_proxies: "%trusted_proxies%"
     session:         ~
     fragments:       ~
     http_method_override: true

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -13,11 +13,7 @@ parameters:
     database_password: logincidadao
     database_server_version: ~
 
-    # Trusted proxies (http://symfony.com/doc/current/cookbook/request/load_balancer_reverse_proxy.html)
-    trusted_proxies: []
-    # IPs allowed to access dev environment
-    dev_allowed: [ 127.0.0.0/8 ]
-    # IPs allowed to access monitoring endpoint
+    # IPs allowed to access monitoring endpoints
     allowed_monitors: [ 127.0.0.0/8 ]
     # IPs allowed to access accounting endpoint
     allowed_accounting: [ 127.0.0.0/8 ]

--- a/app/config/parameters.yml.vagrant
+++ b/app/config/parameters.yml.vagrant
@@ -7,11 +7,7 @@ parameters:
     database_password: ~
     database_server_version: ~
 
-    # Trusted proxies (http://symfony.com/doc/current/cookbook/request/load_balancer_reverse_proxy.html)
-    trusted_proxies: []
-    # IPs allowed to access dev environment
-    dev_allowed: [ 127.0.0.0/8 ]
-    # IPs allowed to access monitoring endpoint
+    # IPs allowed to access monitoring endpoints
     allowed_monitors: [ 127.0.0.0/8 ]
     # IPs allowed to access accounting endpoint
     allowed_accounting: [ 127.0.0.0/8 ]

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -184,7 +184,7 @@ security:
         - { path: ^/connect/google$, role: IS_AUTHENTICATED_ANONYMOUSLY, requires_channel: https }
         - { path: ^/nfg/(help|select-action|login|create|connect|callback|unavailable|wait|missing-info), role: IS_AUTHENTICATED_ANONYMOUSLY, requires_channel: https }
 
-        - { path: ^/monitor/health, role: IS_AUTHENTICATED_ANONYMOUSLY, ip: %allowed_monitors%, requires_channel: https }
+        - { path: ^/monitor/health, role: IS_AUTHENTICATED_ANONYMOUSLY, ips: "%allowed_monitors%", requires_channel: https }
         - { path: ^/public/status, role: IS_AUTHENTICATED_ANONYMOUSLY, ip: %allowed_monitors%, requires_channel: https }
 
         - { path: ^/nelmio/csp/report$, role: IS_AUTHENTICATED_ANONYMOUSLY }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "procergs/login-cidadao",
-    "version": "1.20.2",
+    "version": "1.21.0",
     "license": "AGPL-3.0",
     "type": "project",
     "description": "login-cidadao",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "945a6cd4d0ecce39d6077c8fa30dd5b3",
+    "content-hash": "97d32455498813c459a0e55ad6d0617d",
     "packages": [
         {
             "name": "beelab/recaptcha2-bundle",

--- a/web/app.php
+++ b/web/app.php
@@ -1,9 +1,13 @@
 <?php
 
+use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\HttpFoundation\Request;
 use LoginCidadao\CoreBundle\Security\Compatibility\RamseyUuidFeatureSet;
 
 $loader = require_once __DIR__.'/../app/autoload.php';
+
+$dotenv = new Dotenv();
+$dotenv->load(__DIR__.'/../.env');
 
 $kernel = new AppKernel('prod', false);
 
@@ -11,6 +15,14 @@ $uuidFactory = new \Ramsey\Uuid\UuidFactory(new RamseyUuidFeatureSet());
 \Ramsey\Uuid\Uuid::setFactory($uuidFactory);
 $generator = new \Qandidate\Stack\UuidRequestIdGenerator();
 $stack = new \Qandidate\Stack\RequestId($kernel, $generator);
+
+try {
+    $trustedProxies = explode(',', getenv('TRUSTED_PROXIES'));
+    Request::setTrustedProxies($trustedProxies);
+} catch (Exception $ex) {
+    http_response_code(500);
+    exit('Invalid configuration');
+}
 
 $request = Request::createFromGlobals();
 

--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -1,7 +1,7 @@
 <?php
 
-use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\Debug\Debug;
+use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\HttpFoundation\IpUtils;
 use Symfony\Component\HttpFoundation\Request;
 use LoginCidadao\CoreBundle\Security\Compatibility\RamseyUuidFeatureSet;
@@ -11,6 +11,10 @@ use LoginCidadao\CoreBundle\Security\Compatibility\RamseyUuidFeatureSet;
 //umask(0000);
 
 $loader = require_once __DIR__.'/../app/autoload.php';
+
+$dotenv = new Dotenv();
+$dotenv->load(__DIR__.'/../.env');
+
 Debug::enable();
 
 $kernel = new AppKernel('dev', true);
@@ -21,11 +25,8 @@ $generator = new \Qandidate\Stack\UuidRequestIdGenerator();
 $stack = new \Qandidate\Stack\RequestId($kernel, $generator);
 
 try {
-    $path = implode(DIRECTORY_SEPARATOR,
-        array($kernel->getRootDir(), 'config', 'parameters.yml'));
-
-    $params = Yaml::parse(file_get_contents($path));
-    Request::setTrustedProxies($params['parameters']['trusted_proxies']);
+    $trustedProxies = explode(',', getenv('TRUSTED_PROXIES'));
+    Request::setTrustedProxies($trustedProxies);
 } catch (Exception $ex) {
     http_response_code(500);
     exit('Invalid configuration');
@@ -33,11 +34,10 @@ try {
 
 $request = Request::createFromGlobals();
 
-$allowed  = $params['parameters']['dev_allowed'];
-$clientIp = $request->getClientIp();
-if (!IpUtils::checkIp($clientIp, $allowed)) {
+$allowed = explode(',', getenv('DEV_ALLOWED'));
+if (!IpUtils::checkIp($request->getClientIp(), $allowed)) {
     header('HTTP/1.0 403 Forbidden');
-    exit("You ($clientIp) are not allowed to access this file.");
+    exit('You are not allowed to access this file.');
 }
 
 // This line is required after Symfony 2.8.44


### PR DESCRIPTION
**Security**:
- PROCERGS#833: Removed deprecated `framework.trusted_proxies` config

# Attention - ACTION NEEDED

Our Trusted Proxies and Dev Allowed IPs config got moved to the `.env` file. Please update your config accordingly.

Before you'd set it in the `parameters.yml` config file.

``` yaml
# app/config/parameters.yml
parameters:
    trusted_proxies:
        - 1.2.3.4/24
        - 10.20.30.40/24
    dev_allowed:
        - 20.30.40.0/16
```

Now it must be set either via Environment Variables or in the `.env` file.

The Env Variables expected are `TRUSTED_PROXIES` and `DEV_ALLOWED` and they expect comma-separated addresses. Example:

```
# .env
TRUSTED_PROXIES=1.2.3.4/24,10.20.30.40/24
DEV_ALLOWED=20.30.40.0/16
```